### PR TITLE
Add signing of AuthnRequest 

### DIFF
--- a/src/AerialShip/LightSaml/Meta/AbstractRequestBuilder.php
+++ b/src/AerialShip/LightSaml/Meta/AbstractRequestBuilder.php
@@ -7,6 +7,7 @@ use AerialShip\LightSaml\Model\Metadata\EntityDescriptor;
 use AerialShip\LightSaml\Model\Metadata\IdpSsoDescriptor;
 use AerialShip\LightSaml\Model\Metadata\SpSsoDescriptor;
 use AerialShip\LightSaml\Model\Protocol\Message;
+use AerialShip\SamlSPBundle\Config\SPSigningProviderInterface;
 
 
 abstract class AbstractRequestBuilder
@@ -21,18 +22,22 @@ abstract class AbstractRequestBuilder
     /** @var \AerialShip\LightSaml\Meta\SpMeta */
     protected $spMeta;
 
+    /** @var SPSigningProviderInterface */
+    protected $signingProvider;
 
 
     /**
      * @param EntityDescriptor $edSP
      * @param EntityDescriptor $edIDP
      * @param SpMeta $spMeta
+     * @param SPSigningProviderInterface $signingProvider
      */
-    public function __construct(EntityDescriptor $edSP, EntityDescriptor $edIDP, SpMeta $spMeta)
+    public function __construct(EntityDescriptor $edSP, EntityDescriptor $edIDP, SpMeta $spMeta, SPSigningProviderInterface $signingProvider = null)
     {
         $this->edSP = $edSP;
         $this->edIDP = $edIDP;
         $this->spMeta = $spMeta;
+        $this->signingProvider = $signingProvider;
     }
 
 
@@ -71,7 +76,21 @@ abstract class AbstractRequestBuilder
         return $this->edSP;
     }
 
+    /**
+     * @param SPSigningProviderInterface $signingProvider
+     */
+    public function setSigningProvider($signingProvider)
+    {
+        $this->signingProvider = $signingProvider;
+    }
 
+    /**
+     * @return SPSigningProviderInterface
+     */
+    public function getSigningProvider()
+    {
+        return $this->signingProvider;
+    }
 
 
     /**

--- a/src/AerialShip/LightSaml/Meta/AbstractRequestBuilder.php
+++ b/src/AerialShip/LightSaml/Meta/AbstractRequestBuilder.php
@@ -7,7 +7,7 @@ use AerialShip\LightSaml\Model\Metadata\EntityDescriptor;
 use AerialShip\LightSaml\Model\Metadata\IdpSsoDescriptor;
 use AerialShip\LightSaml\Model\Metadata\SpSsoDescriptor;
 use AerialShip\LightSaml\Model\Protocol\Message;
-use AerialShip\SamlSPBundle\Config\SPSigningProviderInterface;
+use AerialShip\LightSaml\Model\XmlDSig\Signature;
 
 
 abstract class AbstractRequestBuilder
@@ -22,22 +22,22 @@ abstract class AbstractRequestBuilder
     /** @var \AerialShip\LightSaml\Meta\SpMeta */
     protected $spMeta;
 
-    /** @var SPSigningProviderInterface */
-    protected $signingProvider;
+    /** @var Signature */
+    protected $signature;
 
 
     /**
      * @param EntityDescriptor $edSP
      * @param EntityDescriptor $edIDP
      * @param SpMeta $spMeta
-     * @param SPSigningProviderInterface $signingProvider
+     * @param Signature $signature
      */
-    public function __construct(EntityDescriptor $edSP, EntityDescriptor $edIDP, SpMeta $spMeta, SPSigningProviderInterface $signingProvider = null)
+    public function __construct(EntityDescriptor $edSP, EntityDescriptor $edIDP, SpMeta $spMeta, Signature $signature = null)
     {
         $this->edSP = $edSP;
         $this->edIDP = $edIDP;
         $this->spMeta = $spMeta;
-        $this->signingProvider = $signingProvider;
+        $this->signature = $signature;
     }
 
 
@@ -77,19 +77,19 @@ abstract class AbstractRequestBuilder
     }
 
     /**
-     * @param SPSigningProviderInterface $signingProvider
+     * @param Signature $signature
      */
-    public function setSigningProvider($signingProvider)
+    public function setSigningProvider($signature)
     {
-        $this->signingProvider = $signingProvider;
+        $this->signature = $signature;
     }
 
     /**
-     * @return SPSigningProviderInterface
+     * @return Signature
      */
     public function getSigningProvider()
     {
-        return $this->signingProvider;
+        return $this->signature;
     }
 
 

--- a/src/AerialShip/LightSaml/Meta/AuthnRequestBuilder.php
+++ b/src/AerialShip/LightSaml/Meta/AuthnRequestBuilder.php
@@ -9,6 +9,8 @@ use AerialShip\LightSaml\Helper;
 use AerialShip\LightSaml\Model\Metadata\Service\AssertionConsumerService;
 use AerialShip\LightSaml\Model\Protocol\AuthnRequest;
 use AerialShip\LightSaml\Model\Protocol\Message;
+use AerialShip\LightSaml\Model\XmlDSig\SignatureCreator;
+use AerialShip\SamlSPBundle\Config\SPSigningProviderNull;
 
 class AuthnRequestBuilder extends AbstractRequestBuilder
 {
@@ -33,6 +35,14 @@ class AuthnRequestBuilder extends AbstractRequestBuilder
 
         if ($this->spMeta->getNameIdFormat()) {
             $result->setNameIdPolicyFormat($this->spMeta->getNameIdFormat());
+        }
+
+        $signingProvider = $this->getSigningProvider();
+        if ($signingProvider != null && !($signingProvider instanceof SPSigningProviderNull)) {
+            $signature = new SignatureCreator();
+            $signature->setXmlSecurityKey($signingProvider->getPrivateKey());
+            $signature->setCertificate($signingProvider->getCertificate());
+            $result->setSignature($signature);
         }
 
         return $result;

--- a/src/AerialShip/LightSaml/Meta/AuthnRequestBuilder.php
+++ b/src/AerialShip/LightSaml/Meta/AuthnRequestBuilder.php
@@ -9,8 +9,6 @@ use AerialShip\LightSaml\Helper;
 use AerialShip\LightSaml\Model\Metadata\Service\AssertionConsumerService;
 use AerialShip\LightSaml\Model\Protocol\AuthnRequest;
 use AerialShip\LightSaml\Model\Protocol\Message;
-use AerialShip\LightSaml\Model\XmlDSig\SignatureCreator;
-use AerialShip\SamlSPBundle\Config\SPSigningProviderNull;
 
 class AuthnRequestBuilder extends AbstractRequestBuilder
 {
@@ -37,13 +35,7 @@ class AuthnRequestBuilder extends AbstractRequestBuilder
             $result->setNameIdPolicyFormat($this->spMeta->getNameIdFormat());
         }
 
-        $signingProvider = $this->getSigningProvider();
-        if ($signingProvider != null && !($signingProvider instanceof SPSigningProviderNull)) {
-            $signature = new SignatureCreator();
-            $signature->setXmlSecurityKey($signingProvider->getPrivateKey());
-            $signature->setCertificate($signingProvider->getCertificate());
-            $result->setSignature($signature);
-        }
+        $result->setSignature($this->signature);
 
         return $result;
     }


### PR DESCRIPTION
Add option to set signing provider on AbstractRequestBuilder. If set (and not as SPSigningProviderNull, as is done in SamlSPBundle), add the signature on created AuthnRequest messages.
