### PR TITLE
Improve the composer.json

### DIFF
--- a/bin/phpunit
+++ b/bin/phpunit
@@ -1,1 +1,0 @@
-../vendor/phpunit/phpunit/phpunit

--- a/composer.json
+++ b/composer.json
@@ -1,27 +1,17 @@
 {
     "name": "aerialship/lightsaml",
     "license": "MIT",
-    "type": "project",
     "description": "Light SAML2 php library",
     "autoload": {
-        "psr-0": { "": "src/" }
+        "psr-0": { "AerialShip\\LightSaml\\": "src/" }
     },
     "require": {
         "php": ">=5.3.3",
         "rnijveld/xmlseclibs": "1.3.1",
-        "symfony/console": ">=2.2"
+        "symfony/console": "~2.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.1.*"
-    },
-    "scripts": {
-        "post-install-cmd": [
-        ],
-        "post-update-cmd": [
-        ]
-    },
-    "config": {
-        "bin-dir": "bin"
+        "phpunit/phpunit": "~4.1"
     },
     "bin": ["bin/lightsaml"],
     "prefer-stable": true,


### PR DESCRIPTION
- add a prefix for the autoloading to allow composer to be faster
- add an upper bound for the constraint to avoid issues because of Symfony 3.0 which breaks BC
- change the phpunit constraint to allow uptodate versions
- remove the bin-dir setting to avoid mixing the console scripts with the vendor ones
- remove the `project` type given this package is a library, not a full project
- remove the useless script sections